### PR TITLE
dev: Add api/v1/nodes route and its handler

### DIFF
--- a/api_v1_nodes.go
+++ b/api_v1_nodes.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	log "github.com/sirupsen/logrus"
+	"io"
+	"net/http"
+)
+
+type Result struct {
+	NodeItem struct {
+		InnerXML string `xml:",innerxml"`
+	} `xml:"configuration>nodes"`
+}
+
+type Nodes struct {
+	NodesList []Node `xml:"node" json:"nodes"`
+}
+
+type Node struct {
+	Id    string `xml:"id,attr" json:"id"`
+	Uname string `xml:"uname,attr" json:"uname"`
+}
+
+func handleApiNodesV1(w http.ResponseWriter, cib_data string) bool {
+	xmlData := []byte(cib_data)
+	var result Result
+	err := xml.Unmarshal(xmlData, &result)
+	if err != nil {
+		log.Error(err)
+		return false
+	}
+
+	nodesXML := []byte(fmt.Sprintf("<nodes>%s</nodes>", result.NodeItem.InnerXML))
+	var nodes Nodes
+	err = xml.Unmarshal(nodesXML, &nodes)
+	if err != nil {
+		log.Error(err)
+		return false
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	jsonData, jsonError := json.Marshal(nodes)
+	if jsonError != nil {
+		log.Error(jsonError)
+		return false
+	}
+	io.WriteString(w, string(jsonData))
+	return true
+}

--- a/main.go
+++ b/main.go
@@ -202,6 +202,15 @@ func (handler *routeHandler) serveAPI(w http.ResponseWriter, r *http.Request, ro
 		return true
 	}
 	if r.Method == "GET" {
+		if r.URL.Path == fmt.Sprintf("%s/nodes", route.Path) {
+			return handleApiNodesV1(w, handler.cib.Get())
+		}
+		if r.URL.Path == fmt.Sprintf("%s/resources", route.Path) {
+			fmt.Println("for resources")
+		}
+		if r.URL.Path == fmt.Sprintf("%s/cluster", route.Path) {
+			fmt.Println("for cluster")
+		}
 		if strings.HasPrefix(r.URL.Path, fmt.Sprintf("%s/cib", route.Path)) {
 			xmldoc := handler.cib.Get()
 			w.Header().Set("Content-Type", "application/xml")


### PR DESCRIPTION
* Add api/v1/nodes route in main.go, handler function is handleApiNodesV1 in file api_v1_nodes.go
* Got json data like
  `{"nodes":[{"id":"168430201","uname":"Tbw1"},{"id":"168430202","uname":"Tbw2"}]}`
  in client side
* In api_v1_nodes.go, extract sub xml <nodes> first

Question or discussion:
1. Is this code structure suitable?
2. Is this  a good way to handle xml and json in go? Any better solutions?
3. Is this a good way to handle routes? Do we want to consider some other third-package like mux?