### PR TITLE
dev: Give pretty print by default, controlled by request header

### DIFF
--- a/api_cluster.go
+++ b/api_cluster.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"encoding/xml"
 	log "github.com/sirupsen/logrus"
 	"io"
@@ -21,7 +20,7 @@ func handleApiCluster(w http.ResponseWriter, r *http.Request, cib_data string) b
 
 	w.Header().Set("Content-Type", "application/json")
 
-	jsonData, jsonError := json.Marshal(&cib)
+	jsonData, jsonError := MarshalOut(r, &cib)
 	if jsonError != nil {
 		log.Error(jsonError)
 		return false

--- a/api_common.go
+++ b/api_common.go
@@ -1,6 +1,9 @@
 package main
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"net/http"
+)
 
 //go:generate bash gen.sh
 
@@ -53,4 +56,16 @@ func (c *Cib) MarshalJSON() ([]byte, error) {
 
 	jsonValue, err := json.Marshal(struct_interface)
 	return jsonValue, err
+}
+
+// Common function for pretty print.
+// Give pretty print by default;
+// Give nomal print for efficiency reason,
+// by setting request header "PrettyPrint" as non "1" value on client.
+func MarshalOut(r *http.Request, cib_data *Cib) ([]byte, error) {
+	value := r.Header.Get("PrettyPrint")
+	if value == "" || value == "1" {
+		return json.MarshalIndent(&cib_data, "", "  ")
+	}
+	return json.Marshal(&cib_data)
 }

--- a/api_constraints.go
+++ b/api_constraints.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"encoding/xml"
 	"fmt"
 	log "github.com/sirupsen/logrus"
@@ -52,7 +51,7 @@ func handleApiConstraints(w http.ResponseWriter, r *http.Request, cib_data strin
 		}
 	}
 
-	jsonData, jsonError := json.Marshal(&cib)
+	jsonData, jsonError := MarshalOut(r, &cib)
 	if jsonError != nil {
 		log.Error(jsonError)
 		return false

--- a/api_nodes.go
+++ b/api_nodes.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"encoding/xml"
 	"fmt"
 	log "github.com/sirupsen/logrus"
@@ -46,7 +45,7 @@ func handleApiNodes(w http.ResponseWriter, r *http.Request, cib_data string) boo
 		cib.Configuration.Nodes.URLIndex = index
 	}
 
-	jsonData, jsonError := json.Marshal(&cib)
+	jsonData, jsonError := MarshalOut(r, &cib)
 	if jsonError != nil {
 		log.Error(jsonError)
 		return false

--- a/api_resources.go
+++ b/api_resources.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"encoding/xml"
 	"fmt"
 	log "github.com/sirupsen/logrus"
@@ -55,7 +54,7 @@ func handleApiResources(w http.ResponseWriter, r *http.Request, cib_data string)
 		}
 	}
 
-	jsonData, jsonError := json.Marshal(&cib)
+	jsonData, jsonError := MarshalOut(r, &cib)
 	if jsonError != nil {
 		log.Error(jsonError)
 		return false


### PR DESCRIPTION
I think it will be easy to read the json output that we provide pretty print by default.

And, we could change it as normal print by using 
`-H "PrettyPrint:0"`
in our client code, for some efficiency reasons.