### PR TITLE
dev: Add URLType and URLIndex for each configuration items and status

### DIFF
--- a/api_structs.go
+++ b/api_structs.go
@@ -43,6 +43,8 @@ type Configuration struct {
 type CrmConfig struct {
 	XMLNAME            xml.Name              `xml:"crm_config" json:"-"`
 	ClusterPropertySet []*ClusterPropertySet `xml:"cluster_property_set" json:"cluster_property_set,omitempty"`
+	URLType   string       `json:"-"`
+	URLIndex  int          `json:"-"`
 }
 
 type ClusterPropertySet struct {
@@ -126,6 +128,8 @@ type Nvpair struct {
 type RscDefaults struct {
 	XMLNAME        xml.Name          `xml:"rsc_defaults" json:"-"`
 	MetaAttributes []*MetaAttributes `xml:"meta_attributes" json:"meta_attributes,omitempty"`
+	URLType   string       `json:"-"`
+	URLIndex  int          `json:"-"`
 }
 
 type MetaAttributes struct {
@@ -140,6 +144,8 @@ type MetaAttributes struct {
 type OpDefaults struct {
 	XMLNAME        xml.Name          `xml:"op_defaults" json:"-"`
 	MetaAttributes []*MetaAttributes `xml:"meta_attributes" json:"meta_attributes,omitempty"`
+	URLType   string       `json:"-"`
+	URLIndex  int          `json:"-"`
 }
 
 type Nodes struct {
@@ -428,6 +434,8 @@ type RscTicket struct {
 type FencingTopology struct {
 	XMLNAME      xml.Name        `xml:"fencing-topology" json:"-"`
 	FencingLevel []*FencingLevel `xml:"fencing-level" json:"fencing-level,omitempty"`
+	URLType   string       `json:"-"`
+	URLIndex  int          `json:"-"`
 }
 
 type FencingLevel struct {
@@ -446,6 +454,8 @@ type Acls struct {
 	AclTarget []*AclTarget `xml:"acl_target" json:"acl_target,omitempty"`
 	AclGroup  []*AclGroup  `xml:"acl_group" json:"acl_group,omitempty"`
 	AclRole   []*AclRole   `xml:"acl_role" json:"acl_role,omitempty"`
+	URLType   string       `json:"-"`
+	URLIndex  int          `json:"-"`
 }
 
 type AclTarget struct {
@@ -486,6 +496,8 @@ type AclPermission struct {
 type Tags struct {
 	XMLNAME xml.Name `xml:"tags" json:"-"`
 	Tag     []*Tag   `xml:"tag" json:"tag,omitempty"`
+	URLType   string       `json:"-"`
+	URLIndex  int          `json:"-"`
 }
 
 type Tag struct {
@@ -502,6 +514,8 @@ type ObjRef struct {
 type Alerts struct {
 	XMLNAME xml.Name `xml:"alerts" json:"-"`
 	Alert   []*Alert `xml:"alert" json:"alert,omitempty"`
+	URLType   string       `json:"-"`
+	URLIndex  int          `json:"-"`
 }
 
 type Alert struct {
@@ -557,6 +571,8 @@ type Recipient struct {
 
 type Status struct {
 	XMLNAME xml.Name `xml:"status" json:"-"`
+	URLType   string       `json:"-"`
+	URLIndex  int          `json:"-"`
 }
 
 type TypeIndex struct {


### PR DESCRIPTION
Krig, I just noticed that we need specific urltype and urlindex for each configuration member and maybe status section, like nodes/resources/constraints, to fetch all of data or specific index item on client.

If this make sense, you can merge it,  or close it and I will change at cibToGo project:) 