### PR TITLE
High: Require Jinja version higher than 2.10.1 (CVE-2019-10906)

### DIFF
--- a/tools/api-go-structs-requirements.txt
+++ b/tools/api-go-structs-requirements.txt
@@ -1,3 +1,3 @@
-Jinja2==2.10
+Jinja2>=2.10.1
 lxml==4.2.5
 MarkupSafe==1.0


### PR DESCRIPTION
Any version below 2.10.1 represent a security vulnerability.  (CVE-2019-10906)