### PR TITLE
Fix nil pointer dereference when an invalid file is requested (bsc#1199257)

### DIFF
--- a/internal/route_handler.go
+++ b/internal/route_handler.go
@@ -131,7 +131,7 @@ func (handler *routeHandler) serveFile(w http.ResponseWriter, r *http.Request, r
 	}
 	filename := path.Clean(fmt.Sprintf("%v%v", *route.Target, r.URL.Path))
 	info, err := os.Stat(filename)
-	if !os.IsNotExist(err) && !info.IsDir() {
+	if err == nil && !info.IsDir() {
 		log.Debugf("[file] %s", filename)
 		e := fmt.Sprintf(`W/"%x-%x"`, info.ModTime().Unix(), info.Size())
 		if match := r.Header.Get("If-None-Match"); match != "" {

--- a/server/redirect.go
+++ b/server/redirect.go
@@ -27,7 +27,7 @@ func ListenAndServeWithRedirect(addr string, handler http.Handler, cert string, 
 	}
 
 	if config.NextProtos == nil {
-		config.NextProtos = []string{"http1/1"}
+		config.NextProtos = []string{"http/1.1"}
 	}
 
 	var err error


### PR DESCRIPTION
Fix nil pointer dereference when an invalid file is requested (bsc#1199257) and correct the HTTP/1.1 ALPN protocol ID so the server works with Go >=1.17.