### PR TITLE
dev: use go-pacemaker's xmlNode->ToString again

### DIFF
--- a/cib/asynccib.go
+++ b/cib/asynccib.go
@@ -3,7 +3,6 @@ package cib
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"sync"
 	"time"
 
@@ -128,23 +127,11 @@ func (acib *AsyncCib) Version() *pacemaker.CibVersion {
 }
 
 func (acib *AsyncCib) notifyNewCib(cibxml *pacemaker.CibDocument) {
-	/* The pacemaker-3.0.0 drops the support of xml general purpose routines.
-	 * There is no more dump_xml_unformatted to convert  xmlNode -> char*
-	 * And we don't want to reinvent it. Let's just call the 'cibadmin -Q'
-	 * and get it as the text.
-	 */
-	cmd := exec.Command("/usr/sbin/cibadmin", "-Q") // Invalid command for testing
-	text, err := cmd.CombinedOutput()
-
-	if err != nil {
-		msg := fmt.Sprintf("Failed to connect execute cibadmin: %v", err)
-		log.Warnf(msg)
-	}
-
+	text := cibxml.ToString()
 	version := cibxml.Version()
 	log.Infof("[CIB]: %v", version)
 	acib.lock.Lock()
-	acib.xmldoc = string(text)
+	acib.xmldoc = text
 	acib.version = version
 	acib.lock.Unlock()
 	// Notify anyone waiting

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ClusterLabs/hawk-apiserver
 go 1.13
 
 require (
-	github.com/ClusterLabs/go-pacemaker v0.0.0-20250220164558-6fc9deff3ba6
+	github.com/ClusterLabs/go-pacemaker v0.0.0-20250226162851-267530e46cf9
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/ClusterLabs/go-pacemaker v0.0.0-20250220164558-6fc9deff3ba6 h1:LzCpdqoa6sIDmOm4dttDEF+QpQXaOUsz+UR4kpo/wh0=
-github.com/ClusterLabs/go-pacemaker v0.0.0-20250220164558-6fc9deff3ba6/go.mod h1:Z8/kfx30NVPr2Q3t7b7sVdRs//Ba+CR/yCD1gwk4Nrg=
+github.com/ClusterLabs/go-pacemaker v0.0.0-20250226162851-267530e46cf9 h1:bqjpPHCU1NgpTXvQ+8+vHZ2c0ldBcALVCTYu9wS61gI=
+github.com/ClusterLabs/go-pacemaker v0.0.0-20250226162851-267530e46cf9/go.mod h1:Z8/kfx30NVPr2Q3t7b7sVdRs//Ba+CR/yCD1gwk4Nrg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
The `xmlNode->ToString` was broken and disabled as a quick fix. The `xmlNode->ToString` is fixed now and can be used again.